### PR TITLE
Fix: Response 타입 문제 및 BaseTime 오타 수정

### DIFF
--- a/src/main/java/com/outsourcing/common/entity/BaseTime.java
+++ b/src/main/java/com/outsourcing/common/entity/BaseTime.java
@@ -22,5 +22,5 @@ public abstract class BaseTime {
 
 	@LastModifiedDate
 	@Column(nullable = false)
-	private LocalDateTime updateAt;
+	private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/outsourcing/common/entity/BaseTime.java
+++ b/src/main/java/com/outsourcing/common/entity/BaseTime.java
@@ -3,6 +3,7 @@ package com.outsourcing.common.entity;
 import java.time.LocalDateTime;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
@@ -19,7 +20,7 @@ public abstract class BaseTime {
 	@Column(updatable = false, nullable = false)
 	private LocalDateTime createdAt;
 
-	@CreatedDate
+	@LastModifiedDate
 	@Column(nullable = false)
 	private LocalDateTime updateAt;
 }

--- a/src/main/java/com/outsourcing/common/response/ErrorResponse.java
+++ b/src/main/java/com/outsourcing/common/response/ErrorResponse.java
@@ -1,5 +1,7 @@
 package com.outsourcing.common.response;
 
+import java.util.List;
+
 import com.outsourcing.common.exception.ErrorCode;
 
 import lombok.Getter;
@@ -15,4 +17,10 @@ public class ErrorResponse<T> implements Response<T> {
 	public T getData() {
 		return null;
 	}
+
+	@Override
+	public List<ValidationErrorResponse.ValidationError> getErrors() {
+		return null;
+	}
+
 }

--- a/src/main/java/com/outsourcing/common/response/Response.java
+++ b/src/main/java/com/outsourcing/common/response/Response.java
@@ -10,8 +10,10 @@ public interface Response<T> {
 
 	T getData();
 
-	T getError();
-	
+	ErrorCode getError();
+
+	List<ValidationErrorResponse.ValidationError> getErrors();
+
 	static <T> Response<T> of(T data, String message) {
 		return new SuccessResponse<>(data, message);
 	}

--- a/src/main/java/com/outsourcing/common/response/SuccessResponse.java
+++ b/src/main/java/com/outsourcing/common/response/SuccessResponse.java
@@ -1,5 +1,9 @@
 package com.outsourcing.common.response;
 
+import java.util.List;
+
+import com.outsourcing.common.exception.ErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,7 +15,13 @@ public class SuccessResponse<T> implements Response<T> {
 	private final String message;
 
 	@Override
-	public T getError() {
+	public ErrorCode getError() {
 		return null;
 	}
+
+	@Override
+	public List<ValidationErrorResponse.ValidationError> getErrors() {
+		return null;
+	}
+
 }

--- a/src/main/java/com/outsourcing/common/response/ValidationErrorResponse.java
+++ b/src/main/java/com/outsourcing/common/response/ValidationErrorResponse.java
@@ -2,6 +2,8 @@ package com.outsourcing.common.response;
 
 import java.util.List;
 
+import com.outsourcing.common.exception.ErrorCode;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -17,7 +19,7 @@ public class ValidationErrorResponse<T> implements Response<T> {
 	}
 
 	@Override
-	public T getError() {
+	public ErrorCode getError() {
 		return null;
 	}
 


### PR DESCRIPTION
## 📌 PR 요약
- Response 타입 문제 및 BaseTime 오타 수정

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - closed #7
    - ref #3

## 🛠️ 변경 사항
- 주요 변경 사항을 bullet으로 작성해주세요.
   1. Response에서 T getError()에 대한 문제 발생
      - ValidationErrorResponse.ValidationError 클래스에 대한 getter가 없음
      - T getError()를 올바른 제네릭 타입으로 재정의하지 않음
   2. BaseTime에서 updatedAt에 @LastModifiedDate가 아닌 @CreatedDate가 정의되어 있음

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.