### PR TITLE
Feat: `User` 및 `User` 관련 엔티티 생성

### DIFF
--- a/src/main/java/com/outsourcing/common/exception/ErrorCode.java
+++ b/src/main/java/com/outsourcing/common/exception/ErrorCode.java
@@ -11,7 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	// 인증 관련 얘외
+	// 인증 관련 예외
+	INVALID_ROLE(BAD_REQUEST, "유효하지 않은 역할입니다."),
 
 	// 유저 관련 예외
 

--- a/src/main/java/com/outsourcing/domain/user/dto/response/CustomerResponse.java
+++ b/src/main/java/com/outsourcing/domain/user/dto/response/CustomerResponse.java
@@ -1,0 +1,25 @@
+package com.outsourcing.domain.user.dto.response;
+
+import com.outsourcing.domain.user.entity.Customer;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomerResponse {
+
+	private final String name;
+	private final String nickname;
+	private final String email;
+	private final String profileUrl;
+	private final String phoneNumber;
+
+	public static CustomerResponse of(Customer customer) {
+		return new CustomerResponse(
+			customer.getName(),
+			customer.getNickname(),
+			customer.getEmail(),
+			customer.getProfileUrl(),
+			customer.getPhoneNumber()
+		);
+	}
+}

--- a/src/main/java/com/outsourcing/domain/user/entity/Address.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Address.java
@@ -1,0 +1,50 @@
+package com.outsourcing.domain.user.entity;
+
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.GenerationType.*;
+
+import com.outsourcing.common.entity.BaseTime;
+import com.outsourcing.domain.user.enums.AddressStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "address")
+@NoArgsConstructor
+public class Address extends BaseTime {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private String address;
+
+	@Enumerated(STRING)
+	@Column(nullable = false)
+	private AddressStatus status;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "customer_id")
+	private Customer customer;
+
+	public Address(String address) {
+		this.address = address;
+	}
+
+	public void addAddress(String address) {
+		this.address = address;
+		this.customer.getAddresses().add(this);
+	}
+}

--- a/src/main/java/com/outsourcing/domain/user/entity/Address.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Address.java
@@ -3,6 +3,7 @@ package com.outsourcing.domain.user.entity;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
+import static lombok.AccessLevel.*;
 
 import com.outsourcing.common.entity.BaseTime;
 import com.outsourcing.domain.user.enums.AddressStatus;
@@ -20,8 +21,8 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "address")
-@NoArgsConstructor
+@Table(name = "addresses")
+@NoArgsConstructor(access = PROTECTED)
 public class Address extends BaseTime {
 
 	@Id

--- a/src/main/java/com/outsourcing/domain/user/entity/Customer.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Customer.java
@@ -1,0 +1,50 @@
+package com.outsourcing.domain.user.entity;
+
+import static jakarta.persistence.CascadeType.*;
+import static lombok.AccessLevel.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import com.outsourcing.domain.user.enums.UserRole;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@DiscriminatorValue(value = "customer")
+@NoArgsConstructor(access = PROTECTED)
+public class Customer extends User {
+
+	@Column(unique = true)
+	private String nickname;
+
+	@OneToMany(mappedBy = "customer", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
+	private List<Address> addresses = new ArrayList<>();
+
+	public Customer(String email, String password, String name, String phoneNumber,
+		UserRole role) {
+		super(email, password, name, phoneNumber, role);
+		this.nickname = email + "_" + UUID.randomUUID().toString().substring(0, 8);
+	}
+
+	public void changeNickname(String nickname) {
+		this.nickname = nickname;
+	}
+
+	public static Customer toCustomer(User user) {
+		return new Customer(
+			user.getEmail(),
+			user.getPassword(),
+			user.getName(),
+			user.getPhoneNumber(),
+			user.getRole()
+		);
+	}
+}

--- a/src/main/java/com/outsourcing/domain/user/entity/Customer.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Customer.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@DiscriminatorValue(value = "customer")
+@DiscriminatorValue(value = "customers")
 @NoArgsConstructor(access = PROTECTED)
 public class Customer extends User {
 

--- a/src/main/java/com/outsourcing/domain/user/entity/Owner.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Owner.java
@@ -6,11 +6,13 @@ import com.outsourcing.domain.user.enums.UserRole;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "owners")
 @NoArgsConstructor(access = PROTECTED)
 public class Owner extends User {
 

--- a/src/main/java/com/outsourcing/domain/user/entity/Owner.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Owner.java
@@ -1,0 +1,35 @@
+package com.outsourcing.domain.user.entity;
+
+import static lombok.AccessLevel.*;
+
+import com.outsourcing.domain.user.enums.UserRole;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class Owner extends User {
+
+	private int storeCount = 0;
+
+	@Column(nullable = false, updatable = false)
+	private String constantNickname;
+
+	public Owner(String email, String password, String name, String phoneNumber,
+		UserRole role) {
+		super(email, password, name, phoneNumber, role);
+		this.constantNickname = "사장님";
+	}
+
+	public void increaseStoreCount() {
+		this.storeCount += 1;
+	}
+
+	public void decreaseStoreCount() {
+		this.storeCount -= 1;
+	}
+}

--- a/src/main/java/com/outsourcing/domain/user/entity/User.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/User.java
@@ -1,0 +1,80 @@
+package com.outsourcing.domain.user.entity;
+
+import static jakarta.persistence.EnumType.*;
+import static jakarta.persistence.GenerationType.*;
+import static jakarta.persistence.InheritanceType.*;
+import static lombok.AccessLevel.*;
+
+import java.time.LocalDateTime;
+
+import com.outsourcing.common.entity.BaseTime;
+import com.outsourcing.domain.user.enums.UserRole;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorColumn;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Inheritance;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "users")
+@NoArgsConstructor(access = PROTECTED)
+@Inheritance(strategy = JOINED)
+@DiscriminatorColumn(name = "type")
+public class User extends BaseTime {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String email;
+
+	@Column(nullable = false)
+	private String password;
+
+	@Column(nullable = false)
+	private String name;
+
+	private String profileUrl;
+
+	@Column(nullable = false, unique = true)
+	private String phoneNumber;
+
+	@Enumerated(STRING)
+	@Column(nullable = false, updatable = false)
+	private UserRole role;
+
+	private LocalDateTime deletedAt;
+
+	public User(String email, String password, String name, String phoneNumber, UserRole role) {
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.phoneNumber = phoneNumber;
+		this.role = role;
+	}
+
+	public void changePassword(String password) {
+		this.password = password;
+	}
+
+	public void changeProfileUrl(String profileUrl) {
+		this.profileUrl = profileUrl;
+	}
+
+	public void changePhoneNumber(String phoneNumber) {
+		this.phoneNumber = phoneNumber;
+	}
+
+	public void deleteUser() {
+		this.deletedAt = LocalDateTime.now();
+	}
+}
+

--- a/src/main/java/com/outsourcing/domain/user/enums/AddressStatus.java
+++ b/src/main/java/com/outsourcing/domain/user/enums/AddressStatus.java
@@ -1,0 +1,6 @@
+package com.outsourcing.domain.user.enums;
+
+public enum AddressStatus {
+
+	ACTIVE, INACTIVE;
+}

--- a/src/main/java/com/outsourcing/domain/user/enums/UserRole.java
+++ b/src/main/java/com/outsourcing/domain/user/enums/UserRole.java
@@ -1,0 +1,24 @@
+package com.outsourcing.domain.user.enums;
+
+import static com.outsourcing.common.exception.ErrorCode.*;
+
+import com.outsourcing.common.exception.BaseException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum UserRole {
+
+	ROLE_CUSTOMER, ROLE_OWNER;
+
+	public static UserRole from(String role) {
+		for (UserRole value : values()) {
+			if (value.toString().equalsIgnoreCase(role)) {
+				return value;
+			}
+		}
+		throw new BaseException(INVALID_ROLE);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,4 @@
 spring:
   config:
     import:
-      - classpath:/prod/application-prod.yml
+      - classpath:/local/application-local.yml


### PR DESCRIPTION
## 📌 PR 요약
- `User` 및 `User` 관련 엔티티 생성

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - closed #9 

## 🛠️ 변경 사항
- 생성/수정일 자동 입력을 위한 `BaseTime` 생성
- 공통 필드를 모아놓은 `User` 생성 및 상속 전략 JOINED 설정
- `Customer`, `Owner`는 `User` 상속 후 각기 다른 필드를 가짐
- `Address`는 유저에서만 사용하기 때문에 유저 도메인 내부에 두었음
- `UserRole`을 찾지 못할 경우를 위한 `ErrorCode` 추가

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- 당장 유저 서비스를 구현하기엔 인증/인가가 우선 순위인 것 같아서 인증/인가 구현한 뒤 모자란 부분이나 누락된 부분 등 채워넣을 예정입니다.
- 문서 현행화는 인증/인가 구현 이후 일괄적으로 하겠습니다.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.