### PR TITLE
Feat: 유저 인증/인가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     // mysql driver
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // redis driver + access
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // jjwt
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/outsourcing/common/exception/ErrorCode.java
+++ b/src/main/java/com/outsourcing/common/exception/ErrorCode.java
@@ -13,16 +13,27 @@ public enum ErrorCode {
 
 	// 인증 관련 예외
 	INVALID_ROLE(BAD_REQUEST, "유효하지 않은 역할입니다."),
+	INVALID_TOKEN_SIGNATURE(BAD_REQUEST, "유효하지 않은 토큰 서명입니다."),
+	INVALID_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
+	TOKEN_ALREADY_EXPIRED(BAD_REQUEST, "만료된 토큰입니다."),
+	UNSUPPORTED_TOKEN(BAD_REQUEST, "지원되지 않는 토큰입니다."),
+	MISSING_AUTHORIZATION_HEADER(UNAUTHORIZED, "JWT 토큰이 존재하지 않습니다."),
+	MISSING_AUTHENTICATION_INFORMATION(UNAUTHORIZED, "인증 정보가 누락되었습니다."),
+	ACCESS_DENIED(FORBIDDEN, "권한이 부족합니다."),
+	LOGIN_FAILED(BAD_REQUEST, "로그인에 실패했습니다."),
+	EMAIL_DUPLICATED(CONFLICT, "중복된 이메일입니다."),
+	PHONE_NUMBER_DUPLICATED(CONFLICT, "중복된 휴대폰 번호입니다."),
 
 	// 유저 관련 예외
+	USER_NOT_FOUND(NOT_FOUND, "유저를 찾을 수 없습니다."),
 
-	// 주문 관련 얘외
+	// 주문 관련 예외
 
 	// 이후 내용을 추가
 
 	TYPE_MISMATCH(BAD_REQUEST, "잘못된 타입입니다."),
 
-	// 서버 관련 얘외
+	// 서버 관련 예외
 	SERVER_NOT_WORK(INTERNAL_SERVER_ERROR, "서버 문제로 인해 실패했습니다.");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/outsourcing/common/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/outsourcing/common/exception/GlobalControllerAdvice.java
@@ -22,7 +22,7 @@ public class GlobalControllerAdvice {
 	@ExceptionHandler(BaseException.class)
 	public Response<BaseException> baseExceptionHandler(BaseException be) {
 		ErrorCode errorCode = be.getErrorCode();
-		return Response.error(errorCode);
+		return Response.error(errorCode, errorCode.getMessage());
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
@@ -48,12 +48,12 @@ public class GlobalControllerAdvice {
 			? "Unknown" : matme.getRequiredType().getSimpleName();
 		log.error("[MethodArgumentTypeMismatchException] field: {}, expected: {}, value:{}", matme.getName(),
 			expectedType, matme.getValue());
-		return Response.error(TYPE_MISMATCH);
+		return Response.error(TYPE_MISMATCH, TYPE_MISMATCH.getMessage());
 	}
 
 	@ExceptionHandler(Exception.class)
 	public Response<Exception> exceptionHandler(Exception e) {
 		log.error("[Exception]: {}", e.getLocalizedMessage());
-		return Response.error(SERVER_NOT_WORK);
+		return Response.error(SERVER_NOT_WORK, SERVER_NOT_WORK.getMessage());
 	}
 }

--- a/src/main/java/com/outsourcing/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/outsourcing/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,113 @@
+package com.outsourcing.common.filter;
+
+import static com.outsourcing.common.exception.ErrorCode.*;
+import static org.springframework.http.MediaType.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.outsourcing.common.exception.BaseException;
+import com.outsourcing.common.exception.ErrorCode;
+import com.outsourcing.common.response.Response;
+import com.outsourcing.common.util.jwt.JwtTokenProvider;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final List<String> whitelist = new ArrayList<>(
+		List.of("/api/v1/auth/customers", "/api/v1/auth/owners", "/api/v1/auth/sign-in", "/api/v1/auth/reissue"));
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String requestURI = request.getRequestURI();
+
+		// whitelist에 해당하는 URL이면 토큰 검증을 건너뛰고 바로 다음 필터로 넘어감
+		boolean isWhitelisted = whitelist.stream().anyMatch(requestURI::startsWith);
+		if (isWhitelisted) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		String accessTokenWithBearer = request.getHeader("Authorization");
+
+		// Header에 토큰이 존재하는지 확인
+		if (accessTokenWithBearer == null || !accessTokenWithBearer.startsWith("Bearer ")) {
+			returnErrorResponse(MISSING_AUTHORIZATION_HEADER, response);
+			return;
+		}
+
+		Boolean isBlacklisted = redisTemplate.hasKey("blacklist:" + accessTokenWithBearer);
+		if (Boolean.TRUE.equals(isBlacklisted)) {
+			returnErrorResponse(MISSING_AUTHENTICATION_INFORMATION, response);
+			return;
+		}
+
+		String accessTokenWithoutBearer = jwtTokenProvider.substringToken(accessTokenWithBearer);
+		try {
+			// 만료 시간 검증
+			if (!jwtTokenProvider.isTokenValidated(accessTokenWithoutBearer)) {
+				throw new BaseException(INVALID_TOKEN);
+			}
+
+			// claims가 비어 있는지 검증
+			Claims claims = jwtTokenProvider.extractClaims(accessTokenWithoutBearer);
+			if (claims == null) {
+				throw new BaseException(INVALID_TOKEN);
+			}
+
+			// SecurityContextHolder에 저장
+			Authentication authentication = jwtTokenProvider.getAuthentication(accessTokenWithoutBearer);
+			SecurityContextHolder.getContext().setAuthentication(authentication);
+		} catch (SecurityException | MalformedJwtException e) {
+			log.error("[{}]: {}", e.getClass().getSimpleName(), e.getLocalizedMessage());
+			returnErrorResponse(INVALID_TOKEN_SIGNATURE, response);
+		} catch (ExpiredJwtException e) {
+			log.error("[{}]: {}", e.getClass().getSimpleName(), e.getLocalizedMessage());
+			returnErrorResponse(TOKEN_ALREADY_EXPIRED, response);
+		} catch (UnsupportedJwtException e) {
+			log.error("[{}]: {}", e.getClass().getSimpleName(), e.getLocalizedMessage());
+			returnErrorResponse(UNSUPPORTED_TOKEN, response);
+		} catch (BaseException e) {
+			log.error("[{}]: {}", e.getClass().getSimpleName(), e.getLocalizedMessage());
+			returnErrorResponse(e.getErrorCode(), response);
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private void returnErrorResponse(ErrorCode errorCode, HttpServletResponse response) throws IOException {
+		response.setStatus(errorCode.getHttpStatus().value());
+		response.setContentType(APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+		Response<ErrorCode> error = Response.error(errorCode, errorCode.getMessage());
+
+		// 응답 구조를 맞춰주기 위해 ObjectMapper 사용
+		ObjectMapper objectMapper = new ObjectMapper();
+		response.getWriter().write(objectMapper.writeValueAsString(error));
+	}
+}

--- a/src/main/java/com/outsourcing/common/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/outsourcing/common/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,57 @@
+package com.outsourcing.common.filter;
+
+import static com.outsourcing.common.exception.ErrorCode.*;
+import static org.springframework.http.MediaType.*;
+
+import java.io.IOException;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.outsourcing.common.exception.ErrorCode;
+import com.outsourcing.common.response.Response;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String requestURI = request.getRequestURI();
+		if (requestURI.startsWith("/api/v1/auth")) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !authentication.isAuthenticated()) {
+			log.error("인증 정보 누락");
+			returnErrorResponse(MISSING_AUTHENTICATION_INFORMATION, response);
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private void returnErrorResponse(ErrorCode errorCode, HttpServletResponse response) throws IOException {
+		response.setStatus(errorCode.getHttpStatus().value());
+		response.setContentType(APPLICATION_JSON_VALUE);
+		response.setCharacterEncoding("UTF-8");
+		Response<ErrorCode> error = Response.error(errorCode, errorCode.getMessage());
+
+		// 응답 구조를 맞춰주기 위해 ObjectMapper 사용
+		ObjectMapper objectMapper = new ObjectMapper();
+		response.getWriter().write(objectMapper.writeValueAsString(error));
+	}
+}

--- a/src/main/java/com/outsourcing/common/response/ErrorResponse.java
+++ b/src/main/java/com/outsourcing/common/response/ErrorResponse.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 public class ErrorResponse<T> implements Response<T> {
 
 	private final ErrorCode error;
+	private final String message;
 
 	@Override
 	public T getData() {

--- a/src/main/java/com/outsourcing/common/response/Response.java
+++ b/src/main/java/com/outsourcing/common/response/Response.java
@@ -18,8 +18,8 @@ public interface Response<T> {
 		return new SuccessResponse<>(data, message);
 	}
 
-	static <T> Response<T> error(ErrorCode code) {
-		return new ErrorResponse<>(code);
+	static <T> Response<T> error(ErrorCode code, String message) {
+		return new ErrorResponse<>(code, message);
 	}
 
 	static <T> Response<T> validationError(List<ValidationErrorResponse.ValidationError> errors) {

--- a/src/main/java/com/outsourcing/common/util/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/outsourcing/common/util/jwt/JwtTokenProvider.java
@@ -1,0 +1,115 @@
+package com.outsourcing.common.util.jwt;
+
+import static com.outsourcing.common.exception.ErrorCode.*;
+import static io.jsonwebtoken.Jwts.SIG.*;
+import static io.jsonwebtoken.io.Decoders.*;
+
+import java.util.Date;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import com.outsourcing.common.exception.BaseException;
+import com.outsourcing.domain.auth.service.CustomUserDetails;
+import com.outsourcing.domain.auth.service.CustomUserDetailsService;
+import com.outsourcing.domain.user.enums.UserRole;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+	private static final String BEARER_PREFIX = "Bearer ";
+	private final CustomUserDetailsService userDetailsService;
+	private SecretKey key;
+	@Value("${jwt.secret.expiration}")
+	private long expiration;
+
+	@Value("${jwt.secret.key}")
+	private String secretKey;
+
+	@Value("${jwt.secret.issuer}")
+	private String issuer;
+
+	@PostConstruct    // 설정 파일에서 값을 읽어오기 때문에 애플리케이션이 완전히 올라간 이후 초기화 하도록 함
+	public void init() {
+		byte[] keyBytes = BASE64.decode(secretKey);
+		key = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public String generateAccessToken(Long id, String email, UserRole userRole) {
+		Date now = new Date(System.currentTimeMillis());
+		return BEARER_PREFIX + Jwts.builder()
+			.header()
+			.add("typ", "JWT")
+			.and()
+			.subject(email)
+			.claim("userId", id)
+			.claim("userRole", userRole)
+			.issuedAt(now)
+			.expiration(new Date(now.getTime() + (1000 * 60 * 15)))
+			.issuer(issuer)
+			.signWith(key, HS256)
+			.compact();
+	}
+
+	public String generateRefreshToken(String email) {
+		Date now = new Date(System.currentTimeMillis());
+		return Jwts.builder()
+			.header()
+			.add("typ", "JWT")
+			.and()
+			.subject(email)
+			.issuedAt(now)
+			.expiration(new Date(now.getTime() + expiration))
+			.issuer(issuer)
+			.signWith(key, HS256)
+			.compact();
+	}
+
+	public String substringToken(String token) {
+		if (StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX)) {
+			return token.substring(7);
+		}
+		throw new BaseException(INVALID_TOKEN);
+	}
+
+	public Claims extractClaims(String token) {
+		return Jwts.parser()
+			.verifyWith(key)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload();
+	}
+
+	public Authentication getAuthentication(String token) {
+		String subject = getSubject(token);
+		CustomUserDetails userDetails = (CustomUserDetails)userDetailsService.loadUserByUsername(subject);
+		return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+	}
+
+	public boolean isTokenValidated(String token) {
+		Claims payload = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+		// 만료 시간이 현재보다 과거가 아니고, 발급한 사람이 동일하면 true
+		return !payload.getExpiration().before(new Date()) && payload.getIssuer().equals(issuer);
+	}
+
+	public String getSubject(String token) {
+		return Jwts.parser()
+			.verifyWith(key)
+			.build()
+			.parseSignedClaims(token)
+			.getPayload()
+			.getSubject();
+	}
+}

--- a/src/main/java/com/outsourcing/config/RedisConfig.java
+++ b/src/main/java/com/outsourcing/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.outsourcing.config;
+
+import static org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents.*;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = ON_STARTUP)
+@RequiredArgsConstructor
+public class RedisConfig {
+
+	@Value("${redis.host}")
+	private String host;
+
+	@Value("${redis.port}")
+	private int port;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration redisConfiguration = new RedisStandaloneConfiguration();
+		redisConfiguration.setHostName(host);
+		redisConfiguration.setPort(port);
+		return new LettuceConnectionFactory(host, port);    // Jedis 역시 지원하지만 성능 상 Lettuce 선택함 (동기, 비동기, 논블로킹 모두 지원)
+	}
+
+	@Bean
+	public RedisTemplate<?, ?> redisTemplate() {
+		RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/outsourcing/config/SecurityConfig.java
+++ b/src/main/java/com/outsourcing/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.outsourcing.config;
+
+import static com.outsourcing.domain.user.enums.UserRole.*;
+import static org.springframework.http.HttpMethod.*;
+import static org.springframework.security.config.http.SessionCreationPolicy.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.outsourcing.common.filter.JwtAuthenticationFilter;
+import com.outsourcing.common.filter.JwtAuthorizationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	private final JwtAuthorizationFilter jwtAuthorizationFilter;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http.httpBasic(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(STATELESS))
+			.csrf(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(request ->
+				request.requestMatchers(POST, "/api/*/auth/**")
+					.permitAll()
+					.requestMatchers(POST, "/api/*/auth/logout")
+					.authenticated()
+					.requestMatchers("/api/*/owners/**").hasAuthority(OWNER.getAuthority())
+					.requestMatchers("/api/*/customers/**").hasAuthority(CUSTOMER.getAuthority())
+					.anyRequest().authenticated())
+			.cors(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.addFilterBefore(jwtAuthorizationFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(jwtAuthenticationFilter, JwtAuthorizationFilter.class);
+		return http.build();
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/outsourcing/domain/auth/controller/AuthController.java
@@ -1,0 +1,61 @@
+package com.outsourcing.domain.auth.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.outsourcing.common.response.Response;
+import com.outsourcing.domain.auth.dto.request.CustomerSignUpRequest;
+import com.outsourcing.domain.auth.dto.request.LogoutRequest;
+import com.outsourcing.domain.auth.dto.request.OwnerSignUpRequest;
+import com.outsourcing.domain.auth.dto.request.SignInRequest;
+import com.outsourcing.domain.auth.dto.request.TokenReissueRequest;
+import com.outsourcing.domain.auth.dto.response.TokenResponse;
+import com.outsourcing.domain.auth.service.AuthService;
+import com.outsourcing.domain.auth.service.CustomUserDetails;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AuthController {
+
+	private final AuthService authService;
+
+	@PostMapping("/v1/auth/customers")
+	public Response<TokenResponse> signUpCustomer(@Valid @RequestBody CustomerSignUpRequest request) {
+		TokenResponse tokenResponse = authService.signUp(request.getEmail(), request.getPassword(), request.getName(),
+			request.getPhoneNumber(), request.getUserRole());
+		return Response.of(tokenResponse, "Customer 회원가입 성공");
+	}
+
+	@PostMapping("/v1/auth/owners")
+	public Response<TokenResponse> signUpOwners(@Valid @RequestBody OwnerSignUpRequest request) {
+		TokenResponse tokenResponse = authService.signUp(request.getEmail(), request.getPassword(), request.getName(),
+			request.getPhoneNumber(), request.getUserRole());
+		return Response.of(tokenResponse, "Owner 회원가입 성공");
+	}
+
+	@PostMapping("/v1/auth/sign-in")
+	public Response<TokenResponse> signIn(@Valid @RequestBody SignInRequest request) {
+		TokenResponse tokenResponse = authService.signIn(request.getEmail(), request.getPassword());
+		return Response.of(tokenResponse, "로그인 성공");
+	}
+
+	@PostMapping("/v1/auth/reissue")
+	public Response<TokenResponse> tokenReissue(@Valid @RequestBody TokenReissueRequest request) {
+		TokenResponse tokenResponse = authService.tokenReissue(request.getRefreshToken());
+		return Response.of(tokenResponse, "토큰 재발급 성공");
+	}
+
+	@PostMapping("/v1/auth/logout")
+	public Response<Void> logout(@Valid @RequestBody LogoutRequest request,
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		authService.logout(request.getAccessToken(), request.getRefreshToken(), userDetails);
+		return Response.of(null, "로그아웃 되었습니다.");
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
@@ -1,0 +1,45 @@
+package com.outsourcing.domain.auth.dto.request;
+
+import static com.outsourcing.domain.user.enums.UserRole.*;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CustomerSignUpRequest {
+
+	@NotBlank
+	@Email
+	private final String email;
+
+	@NotBlank
+	@Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+	@Pattern(regexp = ".*\\d.*", message = "비밀번호는 숫자를 포함해야 합니다.")
+	@Pattern(regexp = ".*[A-Z].*", message = "비밀번호는 대문자를 포함해야 합니다.")
+	private final String password;
+
+	@NotBlank
+	private final String name;
+
+	@NotBlank
+	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$")
+	private final String phoneNumber;
+
+	private final String userRole;
+
+	private final String address;
+
+	@Builder
+	public CustomerSignUpRequest(String phoneNumber, String name, String password, String email, String address) {
+		this.phoneNumber = phoneNumber;
+		this.name = name;
+		this.password = password;
+		this.email = email;
+		this.userRole = CUSTOMER.getAuthority();
+		this.address = address;
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/LogoutRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/LogoutRequest.java
@@ -1,0 +1,16 @@
+package com.outsourcing.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class LogoutRequest {
+
+	@NotBlank
+	private final String accessToken;
+
+	@NotBlank
+	private final String refreshToken;
+}

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/OwnerSignUpRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/OwnerSignUpRequest.java
@@ -1,0 +1,42 @@
+package com.outsourcing.domain.auth.dto.request;
+
+import static com.outsourcing.domain.user.enums.UserRole.*;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OwnerSignUpRequest {
+
+	@NotBlank
+	@Email
+	private final String email;
+
+	@NotBlank
+	@Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
+	@Pattern(regexp = ".*\\d.*", message = "비밀번호는 숫자를 포함해야 합니다.")
+	@Pattern(regexp = ".*[A-Z].*", message = "비밀번호는 대문자를 포함해야 합니다.")
+	private final String password;
+
+	@NotBlank
+	private final String name;
+
+	@NotBlank
+	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$")
+	private final String phoneNumber;
+
+	private final String userRole;
+
+	@Builder
+	public OwnerSignUpRequest(String email, String password, String name, String phoneNumber) {
+		this.email = email;
+		this.password = password;
+		this.name = name;
+		this.phoneNumber = phoneNumber;
+		this.userRole = OWNER.getAuthority();
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/SignInRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/SignInRequest.java
@@ -1,0 +1,16 @@
+package com.outsourcing.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class SignInRequest {
+
+	@NotBlank
+	private final String email;
+
+	@NotBlank
+	private final String password;
+}

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/TokenReissueRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/TokenReissueRequest.java
@@ -1,0 +1,13 @@
+package com.outsourcing.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenReissueRequest {
+
+	@NotBlank
+	private final String refreshToken;
+}

--- a/src/main/java/com/outsourcing/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,17 @@
+package com.outsourcing.domain.auth.dto.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class TokenResponse {
+
+	private final Long id;
+	private final String accessToken;
+	private final String refreshToken;
+
+	public static TokenResponse of(Long id, String accessToken, String refreshToken) {
+		return new TokenResponse(id, accessToken, refreshToken);
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/outsourcing/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,35 @@
+package com.outsourcing.domain.auth.entity;
+
+import static lombok.AccessLevel.*;
+
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+import com.outsourcing.common.entity.BaseTime;
+
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@RedisHash(value = "refreshToken", timeToLive = 60 * 60 * 24 * 14)    // 단위는 초
+public class RefreshToken extends BaseTime {
+
+	@Id
+	private String email;
+
+	@Indexed
+	private String refreshToken;
+
+	@Builder
+	public RefreshToken(String email, String refreshToken) {
+		this.email = email;
+		this.refreshToken = refreshToken;
+	}
+
+	public void updateRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepository.java
@@ -11,4 +11,8 @@ public interface RefreshTokenRepository {
 	Optional<RefreshToken> findByEmail(String email);
 
 	void delete(String email);
+
+	String getKey(String email);
+
+	void addBlacklist(String accessToken, long expiration);
 }

--- a/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,14 @@
+package com.outsourcing.domain.auth.repository;
+
+import java.util.Optional;
+
+import com.outsourcing.domain.auth.entity.RefreshToken;
+
+public interface RefreshTokenRepository {
+
+	void save(RefreshToken refreshToken);
+
+	Optional<RefreshToken> findByEmail(String email);
+
+	void delete(String email);
+}

--- a/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepositoryImpl.java
@@ -51,10 +51,12 @@ public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
 		return Optional.of(new RefreshToken(email, refreshToken));
 	}
 
+	@Override
 	public String getKey(String email) {
 		return redisTemplate.opsForValue().get(email);
 	}
 
+	@Override
 	public void addBlacklist(String accessToken, long expiration) {
 		redisTemplate.opsForValue().set("blacklist:" + accessToken, "logout", expiration, MILLISECONDS);
 	}

--- a/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/outsourcing/domain/auth/repository/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,66 @@
+package com.outsourcing.domain.auth.repository;
+
+import static java.util.concurrent.TimeUnit.*;
+
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import com.outsourcing.domain.auth.entity.RefreshToken;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Value("${redis.timeout}")
+	private Long timeout;
+
+	@Override
+	public void save(RefreshToken refreshToken) {
+		// opsFor: 특정 컬렉션의 작업(operation)들을 호출할 수 있는 인터페이스를 반환. 현재는 String을 위한 것
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+		// 만약 이미 그 email을 key값으로 한 refreshToken이 있을 경우, 업데이트를 위해 삭제
+		if (valueOperations.get(refreshToken.getEmail()) != null) {
+			redisTemplate.delete(refreshToken.getEmail());
+		}
+
+		// redis에 refreshToken을 저장
+		valueOperations.set(refreshToken.getEmail(), refreshToken.getRefreshToken());
+
+		// refreshToken 시간 지정 -> 14일
+		redisTemplate.expire(refreshToken.getEmail(), timeout, SECONDS);
+	}
+
+	@Override
+	public Optional<RefreshToken> findByEmail(String email) {
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+		String refreshToken = valueOperations.get(email);
+
+		if (refreshToken == null) {
+			return Optional.empty();
+		}
+
+		return Optional.of(new RefreshToken(email, refreshToken));
+	}
+
+	public String getKey(String email) {
+		return redisTemplate.opsForValue().get(email);
+	}
+
+	public void addBlacklist(String accessToken, long expiration) {
+		redisTemplate.opsForValue().set("blacklist:" + accessToken, "logout", expiration, MILLISECONDS);
+	}
+
+	@Override
+	public void delete(String email) {
+		redisTemplate.delete(email);
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/service/AuthService.java
+++ b/src/main/java/com/outsourcing/domain/auth/service/AuthService.java
@@ -1,0 +1,118 @@
+package com.outsourcing.domain.auth.service;
+
+import static com.outsourcing.common.exception.ErrorCode.*;
+import static com.outsourcing.domain.user.enums.UserRole.*;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.outsourcing.common.exception.BaseException;
+import com.outsourcing.common.util.jwt.JwtTokenProvider;
+import com.outsourcing.domain.auth.dto.response.TokenResponse;
+import com.outsourcing.domain.auth.entity.RefreshToken;
+import com.outsourcing.domain.auth.repository.RefreshTokenRepositoryImpl;
+import com.outsourcing.domain.user.entity.Customer;
+import com.outsourcing.domain.user.entity.User;
+import com.outsourcing.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final JwtTokenProvider tokenProvider;
+	private final RefreshTokenRepositoryImpl refreshTokenRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+
+	@Transactional
+	public TokenResponse signUp(String email, String password, String name, String phoneNumber, String role) {
+		// 이메일 중복 검사
+		if (userRepository.existsByEmail(email)) {
+			throw new BaseException(EMAIL_DUPLICATED);
+		}
+
+		// 전화번호 중복 검사
+		if (userRepository.existsByPhoneNumber(phoneNumber)) {
+			throw new BaseException(PHONE_NUMBER_DUPLICATED);
+		}
+
+		String encodedPassword = passwordEncoder.encode(password);
+		Customer newCustomer = userRepository.save(
+			new Customer(email, encodedPassword, phoneNumber, name, from(role)));
+
+		String accessToken = tokenProvider.generateAccessToken(newCustomer.getId(), newCustomer.getEmail(),
+			newCustomer.getRole());
+		String refreshToken = tokenProvider.generateRefreshToken(newCustomer.getEmail());
+
+		// 생성된 refreshToken을 redis에 저장
+		refreshTokenRepository.save(new RefreshToken(newCustomer.getEmail(), refreshToken));
+
+		return TokenResponse.of(newCustomer.getId(), accessToken, refreshToken);
+	}
+
+	@Transactional
+	public TokenResponse signIn(String email, String password) {
+		User getUser = userRepository.findByEmailAndDeletedAt(email)
+			.orElseThrow(() -> new BaseException(LOGIN_FAILED));
+
+		if (!passwordEncoder.matches(password, getUser.getPassword())) {
+			throw new BaseException(LOGIN_FAILED);
+		}
+
+		String accessToken = tokenProvider.generateAccessToken(getUser.getId(), getUser.getEmail(),
+			getUser.getRole());
+		String refreshToken = tokenProvider.generateRefreshToken(getUser.getEmail());
+
+		refreshTokenRepository.save(new RefreshToken(getUser.getEmail(), refreshToken));
+
+		return TokenResponse.of(getUser.getId(), accessToken, refreshToken);
+	}
+
+	@Transactional
+	public TokenResponse tokenReissue(String refreshToken) {
+		if (!jwtTokenProvider.isTokenValidated(refreshToken)) {
+			throw new BaseException(INVALID_TOKEN);
+		}
+
+		String email = jwtTokenProvider.getSubject(refreshToken);
+
+		RefreshToken getRefreshToken = refreshTokenRepository.findByEmail(email)
+			.orElseThrow(() -> new BaseException(INVALID_TOKEN));
+
+		if (!getRefreshToken.getRefreshToken().equals(refreshToken)) {
+			throw new BaseException(INVALID_TOKEN);
+		}
+
+		User getUser = userRepository.findByEmail(email).orElseThrow(() -> new BaseException(USER_NOT_FOUND));
+
+		String newRefreshToken = jwtTokenProvider.generateRefreshToken(getUser.getEmail());
+		String newAccessToken = jwtTokenProvider.generateAccessToken(getUser.getId(), getUser.getEmail(),
+			getUser.getRole());
+
+		getRefreshToken.updateRefreshToken(newRefreshToken);
+		refreshTokenRepository.save(getRefreshToken);
+
+		return TokenResponse.of(getUser.getId(), newAccessToken, newRefreshToken);
+	}
+
+	public void logout(String accessToken, String refreshToken, CustomUserDetails userDetails) {
+		String accessTokenWithoutBearer = tokenProvider.substringToken(accessToken);
+
+		if (!tokenProvider.isTokenValidated(accessTokenWithoutBearer)) {
+			throw new BaseException(INVALID_TOKEN);
+		}
+
+		String email = userDetails.getUsername();
+		// redis에 로그인 한 유저의 refreshToken이 null이 아니고, refreshToken의 email이 로그인한 유저의 이메일과 동일하면 삭제
+		if (refreshTokenRepository.getKey(email) != null && tokenProvider.getSubject(refreshToken).equals(email)) {
+			refreshTokenRepository.delete(email);
+		}
+
+		long expiration = tokenProvider.extractClaims(accessTokenWithoutBearer).getExpiration().getTime();
+		refreshTokenRepository.addBlacklist(accessToken, expiration);
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/service/CustomUserDetails.java
+++ b/src/main/java/com/outsourcing/domain/auth/service/CustomUserDetails.java
@@ -1,0 +1,41 @@
+package com.outsourcing.domain.auth.service;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import com.outsourcing.domain.user.dto.UserInfo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+	private final UserInfo userInfo;
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return List.of(new SimpleGrantedAuthority(userInfo.getRole().getAuthority()));
+	}
+
+	@Override
+	public String getPassword() {
+		return userInfo.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return userInfo.getEmail();
+	}
+
+	@Override
+	public boolean isEnabled() {    // 사용자 활성화 여부
+		// 삭제 시간이 적혀있지 않다면 true
+		return userInfo.getDeletedAt() == null;
+	}
+}

--- a/src/main/java/com/outsourcing/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/outsourcing/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package com.outsourcing.domain.auth.service;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import com.outsourcing.domain.user.dto.UserInfo;
+import com.outsourcing.domain.user.entity.User;
+import com.outsourcing.domain.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		User getUser = userRepository.findByEmailAndDeletedAt(email)
+			.orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+		return new CustomUserDetails(UserInfo.of(getUser));
+	}
+}

--- a/src/main/java/com/outsourcing/domain/user/dto/UserInfo.java
+++ b/src/main/java/com/outsourcing/domain/user/dto/UserInfo.java
@@ -1,0 +1,25 @@
+package com.outsourcing.domain.user.dto;
+
+import java.time.LocalDateTime;
+
+import com.outsourcing.domain.user.entity.User;
+import com.outsourcing.domain.user.enums.UserRole;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserInfo {
+
+	private final Long id;
+	private final String email;
+	private final String password;
+	private final UserRole role;
+	private final LocalDateTime deletedAt;
+
+	public static UserInfo of(User user) {
+		return new UserInfo(user.getId(), user.getEmail(), user.getPassword(), user.getRole(), user.getDeletedAt());
+	}
+
+}

--- a/src/main/java/com/outsourcing/domain/user/entity/Customer.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Customer.java
@@ -31,7 +31,8 @@ public class Customer extends User {
 	public Customer(String email, String password, String name, String phoneNumber,
 		UserRole role) {
 		super(email, password, name, phoneNumber, role);
-		this.nickname = email + "_" + UUID.randomUUID().toString().substring(0, 8);
+		int idx = email.indexOf("@");
+		this.nickname = email.substring(0, idx) + "_" + UUID.randomUUID().toString().substring(0, 8);
 	}
 
 	public void changeNickname(String nickname) {

--- a/src/main/java/com/outsourcing/domain/user/enums/UserRole.java
+++ b/src/main/java/com/outsourcing/domain/user/enums/UserRole.java
@@ -11,11 +11,14 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserRole {
 
-	ROLE_CUSTOMER, ROLE_OWNER;
+	CUSTOMER("ROLE_CUSTOMER"),
+	OWNER("ROLE_OWNER");
+
+	private final String authority;
 
 	public static UserRole from(String role) {
 		for (UserRole value : values()) {
-			if (value.toString().equalsIgnoreCase(role)) {
+			if (value.authority.equalsIgnoreCase(role)) {
 				return value;
 			}
 		}

--- a/src/main/java/com/outsourcing/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/outsourcing/domain/user/repository/UserRepository.java
@@ -1,0 +1,22 @@
+package com.outsourcing.domain.user.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.outsourcing.domain.user.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	// 탈퇴 유저 포함 이메일 검색
+	Optional<User> findByEmail(String email);
+
+	// 탈퇴 유저 제외 이메일 검색
+	@Query(value = "select u from User u where u.email = :email and u.deletedAt is null")
+	Optional<User> findByEmailAndDeletedAt(String email);
+
+	boolean existsByEmail(String email);
+
+	boolean existsByPhoneNumber(String phoneNumber);
+}


### PR DESCRIPTION
## 📌 PR 요약
- 유저 인증/인가 구현

## 🔗 관련 이슈
- 관련된 이슈 번호를 연결해주세요.
    - ref #13 

## 🛠️ 변경 사항
- spring security & JWT & redis를 사용해서 구현함
- `JwtAuthorizationFilter`에서 현재는 prefix `/owner` 및 `/customer`로 애플리케이션을 분리한 것처럼 해당 경로로 시작해야만 가능하도록 우선 설정
- 애플리케이션을 실행하기 위해선 redis를 다운받고 설정 파일을 추가해야 함
- 토큰 생성 및 검증을 하는 `JwtTokenProvider`와 redis에 저장 및 삭제 등을 처리하는 `RefreshTokenRepository` 생성
- 이후 유저 기능 추가 후 제대로 테스트 한 뒤 issue 닫을 예정.

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
- Redis 설정이 추가로 필요합니다. 자세한 사항은 slack을 봐주세요!
- 로그인한 유저를 가져오는 방법도 slack을 봐주세요!
- 자세한 테스트를 진행할 수 없어서 단순 회원가입 , 로그인, 토큰 재발급, 로그아웃에 대한 테스트만 진행함. 

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.