### PR TITLE
Refactor: auth, user 패키지 리팩토링

### DIFF
--- a/src/main/java/com/outsourcing/domain/auth/controller/AuthCustomerController.java
+++ b/src/main/java/com/outsourcing/domain/auth/controller/AuthCustomerController.java
@@ -26,7 +26,7 @@ public class AuthCustomerController {
 	@PostMapping("/v1/auth/customers")
 	public Response<TokenResponse> signUpCustomer(@Valid @RequestBody CustomerSignUpRequest request) {
 		TokenResponse tokenResponse = customerService.signUpCustomer(request.getEmail(), request.getPassword(),
-			request.getName(), request.getPhoneNumber(), request.getUserRole(), request.getAddress());
+			request.getName(), request.getPhoneNumber(), request.getAddress());
 		return Response.of(tokenResponse, "Customer 회원가입 성공");
 	}
 

--- a/src/main/java/com/outsourcing/domain/auth/controller/AuthOwnerController.java
+++ b/src/main/java/com/outsourcing/domain/auth/controller/AuthOwnerController.java
@@ -26,7 +26,7 @@ public class AuthOwnerController {
 	@PostMapping("/v1/auth/owners")
 	public Response<TokenResponse> signUpOwner(@Valid @RequestBody OwnerSignUpRequest request) {
 		TokenResponse tokenResponse = ownerService.signUpOwner(request.getEmail(), request.getPassword(),
-			request.getName(), request.getPhoneNumber(), request.getUserRole());
+			request.getName(), request.getPhoneNumber());
 		return Response.of(tokenResponse, "Owner 회원가입 성공");
 	}
 

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
@@ -1,12 +1,9 @@
 package com.outsourcing.domain.auth.dto.request;
 
-import static com.outsourcing.domain.user.enums.UserRole.*;
-
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -29,19 +26,15 @@ public class CustomerSignUpRequest {
 	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$", message = "휴대전화 번호 형식이 아닙니다.")
 	private final String phoneNumber;
 
-	private final String userRole;
-
 	@NotBlank
 	@Pattern(regexp = "^[가-힣0-9 -]+$", message = "주소 형식이 올바르지 않습니다.")
 	private final String address;
 
-	@Builder
 	public CustomerSignUpRequest(String phoneNumber, String name, String password, String email, String address) {
 		this.phoneNumber = phoneNumber;
 		this.name = name;
 		this.password = password;
 		this.email = email;
-		this.userRole = CUSTOMER.getAuthority();
 		this.address = address;
 	}
 }

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public class CustomerSignUpRequest {
 
 	@NotBlank
@@ -30,11 +32,4 @@ public class CustomerSignUpRequest {
 	@Pattern(regexp = "^[가-힣0-9 -]+$", message = "주소 형식이 올바르지 않습니다.")
 	private final String address;
 
-	public CustomerSignUpRequest(String phoneNumber, String name, String password, String email, String address) {
-		this.phoneNumber = phoneNumber;
-		this.name = name;
-		this.password = password;
-		this.email = email;
-		this.address = address;
-	}
 }

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/CustomerSignUpRequest.java
@@ -26,11 +26,13 @@ public class CustomerSignUpRequest {
 	private final String name;
 
 	@NotBlank
-	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$")
+	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$", message = "휴대전화 번호 형식이 아닙니다.")
 	private final String phoneNumber;
 
 	private final String userRole;
 
+	@NotBlank
+	@Pattern(regexp = "^[가-힣0-9 -]+$", message = "주소 형식이 올바르지 않습니다.")
 	private final String address;
 
 	@Builder

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/OwnerSignUpRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/OwnerSignUpRequest.java
@@ -1,15 +1,14 @@
 package com.outsourcing.domain.auth.dto.request;
 
-import static com.outsourcing.domain.user.enums.UserRole.*;
-
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public class OwnerSignUpRequest {
 
 	@NotBlank
@@ -28,15 +27,4 @@ public class OwnerSignUpRequest {
 	@NotBlank
 	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$", message = "휴대전화 번호 형식이 아닙니다.")
 	private final String phoneNumber;
-
-	private final String userRole;
-
-	@Builder
-	public OwnerSignUpRequest(String email, String password, String name, String phoneNumber) {
-		this.email = email;
-		this.password = password;
-		this.name = name;
-		this.phoneNumber = phoneNumber;
-		this.userRole = OWNER.getAuthority();
-	}
 }

--- a/src/main/java/com/outsourcing/domain/auth/dto/request/OwnerSignUpRequest.java
+++ b/src/main/java/com/outsourcing/domain/auth/dto/request/OwnerSignUpRequest.java
@@ -26,7 +26,7 @@ public class OwnerSignUpRequest {
 	private final String name;
 
 	@NotBlank
-	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$")
+	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$", message = "휴대전화 번호 형식이 아닙니다.")
 	private final String phoneNumber;
 
 	private final String userRole;

--- a/src/main/java/com/outsourcing/domain/auth/service/AuthCustomerService.java
+++ b/src/main/java/com/outsourcing/domain/auth/service/AuthCustomerService.java
@@ -15,6 +15,7 @@ import com.outsourcing.domain.auth.entity.RefreshToken;
 import com.outsourcing.domain.auth.repository.RefreshTokenRepository;
 import com.outsourcing.domain.user.entity.Address;
 import com.outsourcing.domain.user.entity.Customer;
+import com.outsourcing.domain.user.repository.AddressRepository;
 import com.outsourcing.domain.user.repository.CustomerRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -27,9 +28,10 @@ public class AuthCustomerService {
 	private final PasswordEncoder passwordEncoder;
 	private final RefreshTokenRepository refreshTokenRepository;
 	private final JwtTokenProvider tokenProvider;
+	private final AddressRepository addressRepository;
 
 	@Transactional
-	public TokenResponse signUpCustomer(String email, String password, String name, String phoneNumber, String role,
+	public TokenResponse signUpCustomer(String email, String password, String name, String phoneNumber,
 		String address) {
 		// 이메일 중복 검사
 		if (customerRepository.existsByEmail(email)) {
@@ -42,11 +44,10 @@ public class AuthCustomerService {
 		}
 
 		String encodedPassword = passwordEncoder.encode(password);
-		Customer newCustomer = new Customer(email, encodedPassword, name, phoneNumber, from(role));
+		Customer newCustomer = customerRepository.save(
+			new Customer(email, encodedPassword, name, phoneNumber, CUSTOMER));
 
-		Address newAddress = Address.from(address, ACTIVE);
-		newCustomer.addAddress(newAddress);
-		customerRepository.save(newCustomer);
+		addressRepository.save(Address.from(address, ACTIVE, newCustomer));
 
 		String accessToken = tokenProvider.generateAccessToken(newCustomer.getId(), newCustomer.getEmail(),
 			newCustomer.getRole());

--- a/src/main/java/com/outsourcing/domain/auth/service/AuthCustomerService.java
+++ b/src/main/java/com/outsourcing/domain/auth/service/AuthCustomerService.java
@@ -44,8 +44,7 @@ public class AuthCustomerService {
 		String encodedPassword = passwordEncoder.encode(password);
 		Customer newCustomer = new Customer(email, encodedPassword, name, phoneNumber, from(role));
 
-		Address newAddress = Address.from(address);
-		newAddress.updateStatus(ACTIVE);
+		Address newAddress = Address.from(address, ACTIVE);
 		newCustomer.addAddress(newAddress);
 		customerRepository.save(newCustomer);
 

--- a/src/main/java/com/outsourcing/domain/auth/service/AuthOwnerService.java
+++ b/src/main/java/com/outsourcing/domain/auth/service/AuthOwnerService.java
@@ -27,7 +27,7 @@ public class AuthOwnerService {
 	private final JwtTokenProvider tokenProvider;
 
 	@Transactional
-	public TokenResponse signUpOwner(String email, String password, String name, String phoneNumber, String role) {
+	public TokenResponse signUpOwner(String email, String password, String name, String phoneNumber) {
 		// 이메일 중복 검사
 		if (ownerRepository.existsByEmail(email)) {
 			throw new BaseException(EMAIL_DUPLICATED);
@@ -40,7 +40,7 @@ public class AuthOwnerService {
 
 		String encodedPassword = passwordEncoder.encode(password);
 		Owner newOwner = ownerRepository.save(
-			new Owner(email, encodedPassword, name, phoneNumber, from(role)));
+			new Owner(email, encodedPassword, name, phoneNumber, OWNER));
 
 		String accessToken = tokenProvider.generateAccessToken(newOwner.getId(), newOwner.getEmail(),
 			newOwner.getRole());

--- a/src/main/java/com/outsourcing/domain/user/controller/CustomerController.java
+++ b/src/main/java/com/outsourcing/domain/user/controller/CustomerController.java
@@ -35,7 +35,7 @@ public class CustomerController {
 	private final CustomerService customerService;
 
 	@GetMapping("/v1/customers/me")
-	public Response<CustomerResponse> getUserProfile(@AuthenticationPrincipal CustomUserDetails currentUser) {
+	public Response<CustomerResponse> getCustomerProfile(@AuthenticationPrincipal CustomUserDetails currentUser) {
 		CustomerResponse response = customerService.getCustomerProfile(currentUser);
 		return Response.of(response, "Customer 프로필 조회 성공");
 	}
@@ -97,7 +97,7 @@ public class CustomerController {
 	}
 
 	@PatchMapping("/v1/customers/me/password")
-	public Response<CustomerResponse> updatePhoneNumber(@Valid @RequestBody UpdatePasswordRequest request,
+	public Response<CustomerResponse> updatePassword(@Valid @RequestBody UpdatePasswordRequest request,
 		@AuthenticationPrincipal CustomUserDetails currentUser) {
 
 		CustomerResponse response = customerService.updatePassword(request.getOldPassword(),
@@ -107,10 +107,10 @@ public class CustomerController {
 
 	//TODO: 파일 시스템 완료 후 테스트 예정
 	@PatchMapping("/v1/customers/me/profile-image")
-	public Response<CustomerResponse> updateProfileUrl(@Valid @RequestBody UpdateProfileUrlRequest request,
+	public Response<CustomerResponse> updateCustomerProfileUrl(@Valid @RequestBody UpdateProfileUrlRequest request,
 		@AuthenticationPrincipal CustomUserDetails currentUser) {
 
-		CustomerResponse response = customerService.updateProfileUrl(request.getNewProfileUrl(), currentUser);
+		CustomerResponse response = customerService.updateCustomerProfileUrl(request.getNewProfileUrl(), currentUser);
 		return Response.of(response, "Customer 프로필 이미지 수정 성공");
 	}
 

--- a/src/main/java/com/outsourcing/domain/user/controller/CustomerController.java
+++ b/src/main/java/com/outsourcing/domain/user/controller/CustomerController.java
@@ -75,7 +75,7 @@ public class CustomerController {
 
 	@GetMapping("/v1/customers/me/addresses")
 	public Response<GetAllAddressResponse> getAllAddresses(@AuthenticationPrincipal CustomUserDetails currentUser) {
-		GetAllAddressResponse response = customerService.getAllAddresses(currentUser);
+		GetAllAddressResponse response = customerService.getAllAddressResponse(currentUser);
 		return Response.of(response, "Customer 주소 전체 조회 성공");
 	}
 

--- a/src/main/java/com/outsourcing/domain/user/controller/OwnerController.java
+++ b/src/main/java/com/outsourcing/domain/user/controller/OwnerController.java
@@ -28,7 +28,7 @@ public class OwnerController {
 	private final OwnerService ownerService;
 
 	@GetMapping("/v1/owners/me")
-	public Response<OwnerResponse> getUserProfile(@AuthenticationPrincipal CustomUserDetails currentUser) {
+	public Response<OwnerResponse> getOwnerProfile(@AuthenticationPrincipal CustomUserDetails currentUser) {
 		OwnerResponse response = ownerService.getOwnerProfile(currentUser);
 		return Response.of(response, "Owner 프로필 조회 성공");
 	}
@@ -42,7 +42,7 @@ public class OwnerController {
 	}
 
 	@PatchMapping("/v1/owners/me/password")
-	public Response<OwnerResponse> updatePhoneNumber(@Valid @RequestBody UpdatePasswordRequest request,
+	public Response<OwnerResponse> updatePassword(@Valid @RequestBody UpdatePasswordRequest request,
 		@AuthenticationPrincipal CustomUserDetails currentUser) {
 
 		OwnerResponse response = ownerService.updatePassword(request.getOldPassword(),
@@ -51,7 +51,7 @@ public class OwnerController {
 	}
 
 	@PostMapping("/v1/owners/me/delete")
-	public Response<Void> deleteCustomer(@Valid @RequestBody DeleteUserRequest request,
+	public Response<Void> deleteOwner(@Valid @RequestBody DeleteUserRequest request,
 		@AuthenticationPrincipal CustomUserDetails currentUser, HttpServletRequest httpServletRequest) {
 
 		String accessToken = httpServletRequest.getHeader("Authorization");

--- a/src/main/java/com/outsourcing/domain/user/dto/AddressDto.java
+++ b/src/main/java/com/outsourcing/domain/user/dto/AddressDto.java
@@ -1,0 +1,24 @@
+package com.outsourcing.domain.user.dto;
+
+import com.outsourcing.domain.user.entity.Address;
+import com.outsourcing.domain.user.enums.AddressStatus;
+
+import lombok.Getter;
+
+@Getter
+public class AddressDto {
+
+	private final Long id;
+	private final String address;
+	private final AddressStatus status;
+
+	private AddressDto(Long id, String address, AddressStatus status) {
+		this.id = id;
+		this.address = address;
+		this.status = status;
+	}
+
+	public static AddressDto from(Address address) {
+		return new AddressDto(address.getId(), address.getAddress(), address.getStatus());
+	}
+}

--- a/src/main/java/com/outsourcing/domain/user/dto/request/UpdatePhoneNumberRequest.java
+++ b/src/main/java/com/outsourcing/domain/user/dto/request/UpdatePhoneNumberRequest.java
@@ -10,6 +10,6 @@ import lombok.RequiredArgsConstructor;
 public class UpdatePhoneNumberRequest {
 
 	@NotBlank
-	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$", message = "휴대전화 번호 형식이 아닙니다.")
+	@Pattern(regexp = "^(010)[0-9]{3,4}[0-9]{4}$", message = "전화번호 형식이 올바르지 않습니다.")
 	private final String newPhoneNumber;
 }

--- a/src/main/java/com/outsourcing/domain/user/dto/request/customer/AddAddressRequest.java
+++ b/src/main/java/com/outsourcing/domain/user/dto/request/customer/AddAddressRequest.java
@@ -1,6 +1,7 @@
 package com.outsourcing.domain.user.dto.request.customer;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,5 +10,6 @@ import lombok.RequiredArgsConstructor;
 public class AddAddressRequest {
 
 	@NotBlank
+	@Pattern(regexp = "^[가-힣0-9 -]+$", message = "주소 형식이 올바르지 않습니다.")
 	private final String address;
 }

--- a/src/main/java/com/outsourcing/domain/user/dto/request/customer/UpdateAddressRequest.java
+++ b/src/main/java/com/outsourcing/domain/user/dto/request/customer/UpdateAddressRequest.java
@@ -1,6 +1,7 @@
 package com.outsourcing.domain.user.dto.request.customer;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,5 +10,6 @@ import lombok.RequiredArgsConstructor;
 public class UpdateAddressRequest {
 
 	@NotBlank
+	@Pattern(regexp = "^[가-힣0-9 -]+$", message = "주소 형식이 올바르지 않습니다.")
 	private final String newAddress;
 }

--- a/src/main/java/com/outsourcing/domain/user/dto/response/GetAllAddressResponse.java
+++ b/src/main/java/com/outsourcing/domain/user/dto/response/GetAllAddressResponse.java
@@ -2,34 +2,20 @@ package com.outsourcing.domain.user.dto.response;
 
 import java.util.List;
 
-import com.outsourcing.domain.user.entity.Address;
-import com.outsourcing.domain.user.enums.AddressStatus;
+import com.outsourcing.domain.user.dto.AddressDto;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class GetAllAddressResponse {
 
-	private final List<AddressResponse> addresses;
+	private List<AddressDto> addressResponses;
 
-	public static GetAllAddressResponse of(List<Address> addresses) {
-		return new GetAllAddressResponse(
-			addresses.stream()
-				.map(AddressResponse::from)
-				.toList()
-		);
+	public GetAllAddressResponse(List<AddressDto> addressResponses) {
+		this.addressResponses = addressResponses;
 	}
 
-	@Getter
-	@RequiredArgsConstructor
-	public static class AddressResponse {
-		private final String address;
-		private final AddressStatus status;
-
-		private static AddressResponse from(Address address) {
-			return new AddressResponse(address.getAddress(), address.getStatus());
-		}
+	public static GetAllAddressResponse of(List<AddressDto> addressResponses) {
+		return new GetAllAddressResponse(addressResponses);
 	}
 }

--- a/src/main/java/com/outsourcing/domain/user/entity/Address.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Address.java
@@ -1,6 +1,5 @@
 package com.outsourcing.domain.user.entity;
 
-import static com.outsourcing.domain.user.enums.AddressStatus.*;
 import static jakarta.persistence.EnumType.*;
 import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
@@ -41,13 +40,13 @@ public class Address extends BaseTime {
 	@JoinColumn(name = "customer_id")
 	private Customer customer;
 
-	private Address(String address) {
+	private Address(String address, AddressStatus status) {
 		this.address = address;
-		this.status = INACTIVE;
+		this.status = status;
 	}
 
-	public static Address from(String address) {
-		return new Address(address);
+	public static Address from(String address, AddressStatus status) {
+		return new Address(address, status);
 	}
 
 	public void updateAddress(String address) {

--- a/src/main/java/com/outsourcing/domain/user/entity/Address.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Address.java
@@ -40,13 +40,14 @@ public class Address extends BaseTime {
 	@JoinColumn(name = "customer_id")
 	private Customer customer;
 
-	private Address(String address, AddressStatus status) {
+	private Address(String address, AddressStatus status, Customer customer) {
 		this.address = address;
 		this.status = status;
+		this.customer = customer;
 	}
 
-	public static Address from(String address, AddressStatus status) {
-		return new Address(address, status);
+	public static Address from(String address, AddressStatus status, Customer customer) {
+		return new Address(address, status, customer);
 	}
 
 	public void updateAddress(String address) {

--- a/src/main/java/com/outsourcing/domain/user/entity/Customer.java
+++ b/src/main/java/com/outsourcing/domain/user/entity/Customer.java
@@ -1,10 +1,7 @@
 package com.outsourcing.domain.user.entity;
 
-import static jakarta.persistence.CascadeType.*;
 import static lombok.AccessLevel.*;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
 
 import com.outsourcing.domain.user.enums.UserRole;
@@ -12,7 +9,6 @@ import com.outsourcing.domain.user.enums.UserRole;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,11 +23,7 @@ public class Customer extends User {
 	@Column(unique = true)
 	private String nickname;
 
-	@OneToMany(mappedBy = "customer", cascade = ALL, orphanRemoval = true)
-	private final List<Address> addresses = new ArrayList<>();
-
-	public Customer(String email, String password, String name, String phoneNumber,
-		UserRole role) {
+	public Customer(String email, String password, String name, String phoneNumber, UserRole role) {
 		super(email, password, name, phoneNumber, role);
 		int idx = email.indexOf("@");
 		this.nickname = email.substring(0, idx) + "_" + UUID.randomUUID().toString().substring(0, 8);
@@ -41,13 +33,4 @@ public class Customer extends User {
 		this.nickname = nickname;
 	}
 
-	public void addAddress(Address address) {
-		addresses.add(address);
-		address.addCustomer(this); // 양방향 관계 설정
-	}
-
-	public void removeAddress(Address address) {
-		addresses.remove(address);
-		address.addCustomer(null); // 양방향 관계 해제
-	}
 }

--- a/src/main/java/com/outsourcing/domain/user/enums/AddressStatus.java
+++ b/src/main/java/com/outsourcing/domain/user/enums/AddressStatus.java
@@ -2,5 +2,6 @@ package com.outsourcing.domain.user.enums;
 
 public enum AddressStatus {
 
-	ACTIVE, INACTIVE;
+	ACTIVE,
+	INACTIVE;
 }

--- a/src/main/java/com/outsourcing/domain/user/repository/AddressRepository.java
+++ b/src/main/java/com/outsourcing/domain/user/repository/AddressRepository.java
@@ -3,11 +3,20 @@ package com.outsourcing.domain.user.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.outsourcing.domain.user.dto.AddressDto;
 import com.outsourcing.domain.user.entity.Address;
 
 public interface AddressRepository extends JpaRepository<Address, Long> {
 
-	List<Address> findAllByCustomerId(Long customerId);
+	@Query("select a from Address a inner join fetch a.customer c where c.id = :customerId")
+	List<Address> findAllByCustomerId(@Param("customerId") Long customerId);
 
+	@Query("select new com.outsourcing.domain.user.dto.AddressDto(" +
+		"a.id, a.address, a.status) " +
+		"from Address a join a.customer c " +
+		"where c.id = :customerId")
+	List<AddressDto> findAddressResponseByCustomerId(@Param("customerId") Long customerId);
 }

--- a/src/main/java/com/outsourcing/domain/user/service/OwnerService.java
+++ b/src/main/java/com/outsourcing/domain/user/service/OwnerService.java
@@ -28,36 +28,36 @@ public class OwnerService {
 
 	@Transactional(readOnly = true)
 	public OwnerResponse getOwnerProfile(CustomUserDetails currentUser) {
-		Owner getOwnerWithoutDeleted = getActiveOwnerByEmail(currentUser.getUsername());
-		return OwnerResponse.of(getOwnerWithoutDeleted);
+		Owner getOwner = getActiveOwnerByEmail(currentUser.getUsername());
+		return OwnerResponse.of(getOwner);
 	}
 
 	@Transactional
 	public OwnerResponse updatePhoneNumber(String newPhoneNumber, CustomUserDetails currentUser) {
-		Owner getOwnerWithDeleted = getOwnerOrElseThrow(currentUser.getUsername());
+		Owner getOwner = getOwnerOrElseThrow(currentUser.getUsername());
 
-		if (getOwnerWithDeleted.getPhoneNumber().equals(newPhoneNumber)) {
+		if (getOwner.getPhoneNumber().equals(newPhoneNumber)) {
 			throw new BaseException(PHONE_NUMBER_SAME_AS_OLD);
 		}
 
-		getOwnerWithDeleted.changePhoneNumber(newPhoneNumber);
-		return OwnerResponse.of(getOwnerWithDeleted);
+		getOwner.changePhoneNumber(newPhoneNumber);
+		return OwnerResponse.of(getOwner);
 	}
 
 	@Transactional
 	public OwnerResponse updatePassword(String oldPassword, String newPassword, CustomUserDetails currentUser) {
-		Owner getOwnerWithoutDeleted = getActiveOwnerByEmail(currentUser.getUsername());
+		Owner getOwner = getActiveOwnerByEmail(currentUser.getUsername());
 
-		if (!passwordEncoder.matches(oldPassword, getOwnerWithoutDeleted.getPassword())) {
+		if (!passwordEncoder.matches(oldPassword, getOwner.getPassword())) {
 			throw new BaseException(PASSWORD_NOT_MATCHED);
 		}
 
-		if (passwordEncoder.matches(newPassword, getOwnerWithoutDeleted.getPassword())) {
+		if (passwordEncoder.matches(newPassword, getOwner.getPassword())) {
 			throw new BaseException(PASSWORD_SAME_AS_OLD);
 		}
 
-		getOwnerWithoutDeleted.changePassword(passwordEncoder.encode(newPassword));
-		return OwnerResponse.of(getOwnerWithoutDeleted);
+		getOwner.changePassword(passwordEncoder.encode(newPassword));
+		return OwnerResponse.of(getOwner);
 	}
 
 	@Transactional


### PR DESCRIPTION
## 📌 PR 요약
-  auth, user 패키지 리팩토링

## 🔗 관련 이슈
- ref #23 
- closed #26 

## 🛠️ 변경 사항
1. auth 패키지
   - `@Valid` 발생 시 message 일관성 있게 변경
   - 변수명, 메서드명 수정
   - Enum 컨벤션 수정
   - `Address` 생성 시 바로 상태 값을 넣을 수 있도록 수정
   - 주소 저장 시 앞, 뒤의 공백 제거 후 저장하도록 수정
2. user 패키지
   - `UserRole` 적용 시 RequestBody로 받아서 처리하던 것을 서비스에서 직접 넣는 방식으로 변경함. (각 역할에 대한 API가 나뉘어져 있어서 굳이 Role을 받아서 처리할 필요가 없다고 판단함)
   - `Address` 생성 시 `Customer` 지정을 하지 않던 코드 수정
   - `Address`와 `Customer`의 관계를 단방향으로 수정
   - `Address`를 필요로 하는 조회 이외엔 모두 `AddressDto`를 조회 시 한번에 가져오도록 수정

## 📸 스크린샷 (선택)
UI 변경 사항이 있다면 스크린샷을 첨부해주세요.

## ⚠️ 주의 사항 (선택)
<strong>Address와 Customer의 관계가 단방향 (Address -> Customer)로 바뀌었습니다!</strong>

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.