### PR TITLE
Feat: 이미지 다중 업로드 구현

### DIFF
--- a/src/main/java/com/outsourcing/common/exception/ErrorCode.java
+++ b/src/main/java/com/outsourcing/common/exception/ErrorCode.java
@@ -51,11 +51,12 @@ public enum ErrorCode {
 	MENU_DELETED(NOT_FOUND, "해당 메뉴는 이미 삭제되었습니다."),
 
 	// 파일 관련 예외
-	S3_PUT_OBJECT_IO_EXCEPTION(INTERNAL_SERVER_ERROR, "이미지를 저장하는 도중에 예외가 발생했습니다."),
+	IMAGE_UPLOAD_IO_EXCEPTION(INTERNAL_SERVER_ERROR, "이미지를 저장하는 도중에 예외가 발생했습니다."),
 	FILE_IS_EMPTY(BAD_REQUEST, "파일이 비어있습니다."),
 	INVALID_FILE_TYPE(BAD_REQUEST, "사진 파일만 업로드 가능합니다."),
 	UPLOAD_ACCESS_DENIED(FORBIDDEN, "해당 위치에 파일을 저장할 권한이 없습니다."),
 	FILE_RESIZE_ERROR(INTERNAL_SERVER_ERROR, "파일 리사이징 중 예외가 발생했습니다."),
+	INVALID_UPLOAD_TYPE(BAD_REQUEST, "해당 타입은 다중 이미지 업로드를 할 수 없습니다."),
 
 	// 기타 예외
 	TYPE_MISMATCH(BAD_REQUEST, "잘못된 타입입니다."),

--- a/src/main/java/com/outsourcing/common/storage/controller/FileUploadController.java
+++ b/src/main/java/com/outsourcing/common/storage/controller/FileUploadController.java
@@ -1,13 +1,17 @@
 package com.outsourcing.common.storage.controller;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.outsourcing.common.response.Response;
+import com.outsourcing.common.storage.dto.response.MultipleUploadResponse;
 import com.outsourcing.common.storage.dto.response.UploadResponse;
 import com.outsourcing.common.storage.service.s3.S3StorageService;
 import com.outsourcing.domain.auth.service.CustomUserDetails;
@@ -23,12 +27,21 @@ public class FileUploadController {
 
 	@PostMapping("/v1/flies")
 	public Response<UploadResponse> uploadFile(
-		//TODO: "[Exception]: Required part 'multipartFile' is not present" 핸들링 필요
 		@RequestPart("multipartFile") MultipartFile multipartFile,
-		String type,
+		@RequestParam("type") String type,
 		@AuthenticationPrincipal CustomUserDetails currentUser
 	) {
 		UploadResponse response = s3StorageService.upload(multipartFile, type, currentUser);
+		return Response.of(response);
+	}
+
+	@PostMapping("/v1/flies/multiples")
+	public Response<MultipleUploadResponse> uploadFile(
+		@RequestPart("multipartFiles") List<MultipartFile> multipartFiles,
+		@RequestParam("type") String type,
+		@AuthenticationPrincipal CustomUserDetails currentUser
+	) {
+		MultipleUploadResponse response = s3StorageService.multipleUpload(multipartFiles, type, currentUser);
 		return Response.of(response);
 	}
 }

--- a/src/main/java/com/outsourcing/common/storage/dto/response/MultipleUploadResponse.java
+++ b/src/main/java/com/outsourcing/common/storage/dto/response/MultipleUploadResponse.java
@@ -1,0 +1,17 @@
+package com.outsourcing.common.storage.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class MultipleUploadResponse {
+
+	private final List<String> uploadUrls;
+
+	public static MultipleUploadResponse of(List<String> uploadUrls) {
+		return new MultipleUploadResponse(uploadUrls);
+	}
+}

--- a/src/main/java/com/outsourcing/common/storage/service/StorageService.java
+++ b/src/main/java/com/outsourcing/common/storage/service/StorageService.java
@@ -1,11 +1,16 @@
 package com.outsourcing.common.storage.service;
 
+import java.util.List;
+
 import org.springframework.web.multipart.MultipartFile;
 
+import com.outsourcing.common.storage.dto.response.MultipleUploadResponse;
 import com.outsourcing.common.storage.dto.response.UploadResponse;
 import com.outsourcing.domain.auth.service.CustomUserDetails;
 
 public interface StorageService {
 
-	UploadResponse upload(MultipartFile multipartFile, String type, CustomUserDetails currentUser);
+	UploadResponse upload(MultipartFile image, String type, CustomUserDetails currentUser);
+
+	MultipleUploadResponse multipleUpload(List<MultipartFile> images, String type, CustomUserDetails currentUser);
 }

--- a/src/main/java/com/outsourcing/common/storage/service/s3/S3StorageService.java
+++ b/src/main/java/com/outsourcing/common/storage/service/s3/S3StorageService.java
@@ -1,9 +1,12 @@
 package com.outsourcing.common.storage.service.s3;
 
 import static com.outsourcing.common.exception.ErrorCode.*;
+import static com.outsourcing.common.storage.enums.UploadType.*;
 import static org.springframework.http.MediaType.*;
 
 import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.outsourcing.common.exception.BaseException;
+import com.outsourcing.common.storage.dto.response.MultipleUploadResponse;
 import com.outsourcing.common.storage.dto.response.UploadResponse;
 import com.outsourcing.common.storage.enums.UploadType;
 import com.outsourcing.common.storage.service.StorageService;
@@ -38,12 +42,12 @@ public class S3StorageService implements StorageService {
 	private String region;
 
 	@Override
-	public UploadResponse upload(MultipartFile multipartFile, String type, CustomUserDetails currentUser) {
-		checkFileType(multipartFile.getContentType());
+	public UploadResponse upload(MultipartFile originalImage, String type, CustomUserDetails currentUser) {
+		checkFileType(originalImage.getContentType());
 
 		// convertedEmail + / + System.currentTimeMillis() + "_" + originalFilename + fileExtension
 		String filename = FileUtils.buildFilename(
-			Objects.requireNonNull(multipartFile.getOriginalFilename()), currentUser.getUsername());
+			Objects.requireNonNull(originalImage.getOriginalFilename()), currentUser.getUsername());
 
 		UserRole currentUserRole = currentUser.getUserInfo().getRole();
 		UploadType uploadType = UploadType.from(type);
@@ -56,16 +60,48 @@ public class S3StorageService implements StorageService {
 		PutObjectRequest request = PutObjectRequest.builder()
 			.bucket(bucket)
 			.key(key)
-			.contentType(multipartFile.getContentType())
+			.contentType(originalImage.getContentType())
 			.build();
 
-		byte[] resizedImageBytes = FileUtils.resize(multipartFile, 300, 300);
+		byte[] resizedImageBytes = FileUtils.resize(originalImage, 300, 300);
 
 		//  리사이즈 후 반환되는 InputStream의 크기와 S3 업로드 시 제공하는 콘텐츠 길이가 일치해야 함
-		s3Client.putObject(request,
+		s3Client.putObject(
+			request,
 			RequestBody.fromInputStream(new ByteArrayInputStream(resizedImageBytes), resizedImageBytes.length));
 		log.info("https://{}.s3.{}.amazonaws.com/{}", bucket, region, key);
 		return UploadResponse.of(key);
+	}
+
+	@Override
+	public MultipleUploadResponse multipleUpload(
+		List<MultipartFile> originalImages,
+		String type,
+		CustomUserDetails currentUser
+	) {
+
+		int counter = 0;
+		UploadType uploadType = UploadType.from(type);
+		if (!uploadType.isAllowedFor(currentUser.getUserInfo().getRole())) {
+			throw new BaseException(UPLOAD_ACCESS_DENIED);
+		}
+		
+		if (uploadType == PROFILES || uploadType == STORES) {
+			throw new BaseException(INVALID_UPLOAD_TYPE);
+		}
+
+		List<String> responses = new ArrayList<>();
+		for (MultipartFile image : originalImages) {
+			try {
+				counter++;
+				UploadResponse upload = upload(image, type, currentUser);
+				responses.add(upload.getUploadUrl());
+			} catch (Exception e) {
+				log.error("{} 번째 업로드 중 예외 발생: {}", counter, e.getLocalizedMessage());
+				throw new BaseException(IMAGE_UPLOAD_IO_EXCEPTION);
+			}
+		}
+		return MultipleUploadResponse.of(responses);
 	}
 
 	private void checkFileType(String contentType) {


### PR DESCRIPTION
## 📌 PR 요약
- 이미지 다중 업로드 구현

## 🔗 관련 이슈
- closed #29 

## 🛠️ 변경 사항
- 단순 반복문을 활용해서 구현함
- 다중 파일 업로드 시 중간에 예외 발생 시 예외 처리 후 바로 예외 던짐
- `StorageService`에 다중 업로드를 위한 추상 메서드 정의함

## 📸 스크린샷 (선택)
| 기능 | 스크린샷 |
| --- | --- |
| customer는 profiles에는 다중 업로드 불가 | ![스크린샷 2025-03-05 230528](https://github.com/user-attachments/assets/4fb157b2-5ee9-459d-8707-537f2a6481ac) |
| customer는 stores에 업로드 불가 | ![스크린샷 2025-03-05 230536](https://github.com/user-attachments/assets/382bd072-adbf-4575-a679-aa96bfaf4256) |
| customer는 menus에 업로드 불가 | ![스크린샷 2025-03-05 230550](https://github.com/user-attachments/assets/3bf67161-247a-47f8-99d5-a42a200e9c08) |
| customer는 reviews에 다중 업로드 가능 | ![스크린샷 2025-03-05 230558](https://github.com/user-attachments/assets/c8180c4f-c8c5-4f21-bfe0-8f2c009cc559) |
| owner는 profiles에 업로드 불가 | ![image](https://github.com/user-attachments/assets/4e6bc37b-cd4b-42c0-9f48-717247c2ea49) |
| owner는 stores에 다중 업로드 불가 | ![image](https://github.com/user-attachments/assets/62ac6b1d-bdae-474c-b427-9f3cfb324b1b) |
| owner는 menus에 다중 업로드 가능 | ![image](https://github.com/user-attachments/assets/d6f925a3-8719-4ebf-a2d9-55d204c4b72c) |
| owner는 reviews에 다중 업로드 가능 | ![image](https://github.com/user-attachments/assets/24357e75-6982-4f21-94a4-828b3afd578b) |

## ⚠️ 주의 사항 (선택)
리뷰어가 알아야 할 중요한 사항이나 주의할 점을 작성해주세요.

## ✅ 체크리스트
PR 작성자가 확인해야 할 항목입니다:
- [x] 코드가 정상적으로 동작하는지 확인했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [x] 코드 리뷰어를 등록했습니다.
- [x] Labels를 등록했습니다.